### PR TITLE
fix: sync article-tag relation and UI handling

### DIFF
--- a/app/articles/ArticlesClient.tsx
+++ b/app/articles/ArticlesClient.tsx
@@ -47,6 +47,8 @@ export default function Articles() {
                     author:authors (
                       name,
                       avatar_url
+                    ), article_tags (
+                    tag:tags ( id, name )
                     )
                   `)
                 .order("created_at", { ascending: false }) // Fetch latest articles
@@ -293,16 +295,18 @@ export default function Articles() {
                                             </h3>
                                             <p className="text-sm text-gray-400">{article.excerpt}</p>
                                             <div className="flex gap-2 pt-1">
-                                                {(article.tags || []).map((tag: string, idx: number) => (
+                                                {(article.article_tags || []).map(({ tag }, idx) => (
                                                     <a
                                                         key={idx}
-                                                        href={`/articles?tag=${tag.toLowerCase().replace(/\s+/g, "-")}`}
+                                                        href={`/articles?tag=${tag.name.toLowerCase().replace(/\s+/g, "-")}`}
                                                         className="category-tag hover:bg-game-blue transition-colors"
                                                     >
-                                                        {tag}
+                                                        {tag.name}
                                                     </a>
                                                 ))}
+
                                             </div>
+
                                             <p className="text-xs text-gray-400 pt-1">
                                                 By <span className="font-medium">{article.author?.name || "Unknown"}</span>
                                             </p>

--- a/types/article.ts
+++ b/types/article.ts
@@ -17,6 +17,10 @@ export interface Article {
 }
 
 export type ArticleForm = Omit<Article, "id" | "views" | "created_at" | "updated_at">
+export type ArticleFormWithTags = ArticleForm & {
+  article_tags?: { tag_id: number }[]
+}
+
 
 export interface Author {
     id: number


### PR DESCRIPTION
- Replaced old JSONB `tags` field with many-to-many relation using `article_tags` join table
- Updated editor to load and save tags via `article_tags`
- Fixed checkboxes to reflect saved tags correctly on edit
- Cleaned article payload to prevent schema errors when saving
- Adjusted TypeScript types with `ArticleFormWithTags` for schema compliance
- Fixed rendering of tags in ArticlesClient using new relation
- Improved error logging for better debugging