### PR TITLE
feat: immediately update featured_image field in articles table after image upload

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -33,6 +33,7 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
     <BlogPost
       article={{
         ...article,
+        featuredImage: article.featured_image,
         author: {
           name: article.authors?.name ?? "Autor desconocido",
           avatar: article.authors?.avatar_url ?? null,

--- a/types/article.ts
+++ b/types/article.ts
@@ -18,7 +18,10 @@ export interface Article {
 
 export type ArticleForm = Omit<Article, "id" | "views" | "created_at" | "updated_at">
 export type ArticleFormWithTags = ArticleForm & {
-  article_tags?: { tag_id: number }[]
+    id?: number; //If dont want to update inmediatly the image of the article, this field is not required, just comment the line or remove it 1/2
+    article_tags?: { 
+        tag_id: number 
+    }[]
 }
 
 


### PR DESCRIPTION
This feature branch implements instant updating of the article's featured image. When a user uploads a new image, the public URL is immediately stored in the featured_image column of the corresponding article record in the database (if it exists). This enhances user experience by ensuring the new image appears instantly after upload, without needing to save the entire article form.

- Adds logic to update the featured_image column right after a successful image upload.
- Error handling added for both upload and database update.
- Keeps state in sync with the latest uploaded image.