### PR TITLE
fix: filter articles by published status only for public users

### DIFF
--- a/app/articles/ArticlesClient.tsx
+++ b/app/articles/ArticlesClient.tsx
@@ -109,6 +109,7 @@ export default function Articles() {
             `)
                 .order("created_at", { ascending: false })
 
+            query = query.eq("status", "published");
             // Filtro por categorías (asume que tienes category_id en la tabla articles)
             if (selectedCategories.length > 0) {
                 query = query.in("category_id", selectedCategories)


### PR DESCRIPTION
Feature: Correct article visibility by status

- Only articles with status 'published' are visible to public users.
- Draft and archived articles are now hidden from all public views, including related articles and tag/category searches.
- Filtering logic moved fully to the frontend for strict status checking.
- Admin panel retains access to all articles, regardless of status.
- Refactored Supabase queries for clarity and security.

This addresses previous issues where draft or archived articles could still appear in listings or related suggestions. Now, public and SEO users will only see published content, making the platform safer and more predictable.